### PR TITLE
Support and test for "libcore" stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: rust
 rust:
+  - 1.6.0
+  - 1.7.0
+  - 1.8.0
+  - 1.9.0
+  - 1.10.0
+  - 1.11.0
+  - beta
   - nightly
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,11 @@ script:
 
 # Use Travis container-based infrastructure
 sudo: false
+
+# Send notifications to homu bot
+notifications:
+    webhooks: http://rust-embedded-bot.herokuapp.com/travis
+
+branches:
+  only:
+    - auto

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ cannot rely on the heap.
 Install/Use
 -----------
 
-You must be using the nightly Rust release to use `fixedvec`, as it relies on
-the unstable libcore feature. If you're building for an embedded system, you're
-probably on the nightly anyway though.
+`fixedvec` is tested against Rust 1.6 through stable, beta, and nightly.
+
+The `#![no_std]` attribute was stabilized for libraries in Rust 1.6, so that is
+the minimum Rust version for which `fixedvec` will compile. Note that building
+_binaries_ without libstd is still unstable and requires nightly Rust.
 
 To use `fixedvec`, add the following to your `Cargo.toml`:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,25 +96,18 @@
 //! * `drain`
 //! * `split_off`
 //!
-//! # Examples
+//! # Example
 //!
 //! Typical usage looks like the following:
 //!
-//! ```rust
-//! #![feature(lang_items, libc, start)]
-//! #![no_std]
-//! #![no_main]
-//!
-//! extern crate libc;
-//!
+//! ```
 //! // Pull in fixedvec
 //! #[macro_use]
 //! extern crate fixedvec;
 //!
 //! use fixedvec::FixedVec;
 //!
-//! #[no_mangle]
-//! pub extern fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+//! fn main() {
 //!     let mut preallocated_space = alloc_stack!([u8; 10]);
 //!     let mut vec = FixedVec::new(&mut preallocated_space);
 //!     assert_eq!(vec.len(), 0);
@@ -125,34 +118,12 @@
 //!
 //!     vec[1] = 5;
 //!     assert_eq!(vec[1], 5);
-//!
-//!     0
 //! }
-//!
-//! // These functions and traits are usually provided by libstd: we have to
-//! // provide them ourselves in no_std.
-//! #[lang = "eh_personality"] extern "C" fn eh_personality() {}
-//! #[lang = "panic_fmt"] extern "C" fn panic_fmt() -> ! { loop {} }
-//!
-//! # // Needed to allow doctest to compile/link cleanly with nostd
-//! # #[allow(non_snake_case)]
-//! # #[no_mangle]
-//! # pub extern "C" fn _Unwind_Resume() -> ! { loop {} }
 //! ```
 //!
-//! If you're building for an embedded system, you will also likely want to
-//! disable stack unwinding by adding the following section(s) to your
-//! Cargo.toml:
-//!
-//! ```toml
-//! [profile.dev]
-//! panic = "abort"
-//!
-//! [profile.release]
-//! panic = "abort"
-//!
-//! # ..etc
-//! ```
+//! If you're building for an embedded system, you will want to refer to the
+//! Rust book section ["No stdlib"](https://doc.rust-lang.org/book/no-stdlib.html)
+//! for instructions on building executables using only libcore.
 
 use core::hash::{Hash, Hasher};
 use core::ops;


### PR DESCRIPTION
As of Rust 1.6, libcore (i.e. #![no_std]) is stable. As a result,
there's no reason that fixedvec cannot compile and test against stable
versions of Rust.

This commit updates the CI scripts to test 1.6-1.11, beta, and nightly.
It also updates the example to remove unstable code, and updates the
README to make explicit that the library does build on stable.

Also add to the README explicit mention that no_std binaries are _not_
yet stable and will still require nightly Rust.

CC @posborne 
